### PR TITLE
Strictly force asset pool usage

### DIFF
--- a/sub/nw-tier4/data/config/export/main/asset/assets_.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/assets_.xml
@@ -8,6 +8,7 @@
   <Include File="./fedoras.include.xml" />
   <Include File="./silverware.include.xml" />
   <Include File="./theater.include.xml" />
+  <Include File="./tiles.include.xml" />
   <Include File="./menu.include.xml" />
   <Include File="./population.include.xml" />
   <Include File="./unlocks.include.xml" />

--- a/sub/nw-tier4/data/config/export/main/asset/bank.include.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/bank.include.xml
@@ -252,9 +252,7 @@
           <Constructable>
             <DestructionCategory>Production</DestructionCategory>
           </Constructable>
-          <Locked>
-            <DefaultLockedState>0</DefaultLockedState>
-          </Locked>
+          <Locked />
           <Object>
             <Variations>
               <Item>
@@ -334,6 +332,25 @@
           <Infolayer />
           <UpgradeList />
         </Values>
+      </Asset>      
+      <Asset>
+        <Template>AssetPool</Template>
+        <Values>
+          <Standard>
+            <GUID>1500040018</GUID>
+            <Name>NW Investment Bank Pool</Name>
+          </Standard>
+          <AssetPool>
+            <AssetList>
+              <Item>
+                <Asset>1500040008</Asset>
+              </Item>
+              <Item>
+                <Asset>1500040011</Asset>
+              </Item>
+            </AssetList>
+          </AssetPool>
+        </Values>
       </Asset>
     </ModOp>
   </Group>
@@ -361,13 +378,6 @@
     <ModOp Type="add" GUID="142734" Path="/Values/FeedbackBuildingGroup/Buildings">
       <Item>
         <Building>1500040011</Building>
-      </Item>
-    </ModOp>
-
-    <!-- add to the asset pool -->
-    <ModOp Type="add" GUID="130049" Path="/Values/AssetPool/AssetList">
-      <Item>
-        <Asset>1500040011</Asset>
       </Item>
     </ModOp>
 

--- a/sub/nw-tier4/data/config/export/main/asset/bank.include.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/bank.include.xml
@@ -136,9 +136,7 @@
             </Tier1>
             <InfoTipHeight>550</InfoTipHeight>
           </ProductionChain>
-          <Locked>
-            <DefaultLockedState>0</DefaultLockedState>
-          </Locked>
+          <Locked />
         </Values>
       </Asset>
     </ModOp>

--- a/sub/nw-tier4/data/config/export/main/asset/fedoras.include.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/fedoras.include.xml
@@ -159,9 +159,7 @@
             <TextOverride>1555000128</TextOverride>
           </Text>
           <ProductionChain />
-          <Locked>
-            <DefaultLockedState>0</DefaultLockedState>
-          </Locked>
+          <Locked />
         </Values>
       </Asset>
     </ModOp>

--- a/sub/nw-tier4/data/config/export/main/asset/geographic.include.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/geographic.include.xml
@@ -235,6 +235,9 @@
           <AssetPool>
             <AssetList>
               <Item>
+                <Asset>1500040000</Asset>
+              </Item>
+              <Item>
                 <Asset>1500040012</Asset>
               </Item>
               <Item>

--- a/sub/nw-tier4/data/config/export/main/asset/geographic.include.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/geographic.include.xml
@@ -49,9 +49,7 @@
               </Item>
             </Tier1>
           </ProductionChain>
-          <Locked>
-            <DefaultLockedState>0</DefaultLockedState>
-          </Locked>
+          <Locked />
         </Values>
       </Asset>
     </ModOp>
@@ -140,9 +138,7 @@
             <GUIType>PublicService</GUIType>
           </Selection>
           <Constructable />
-          <Locked>
-            <DefaultLockedState>0</DefaultLockedState>
-          </Locked>
+          <Locked />
           <SoundEmitter>
             <ActiveSounds>
               <Item>
@@ -227,6 +223,25 @@
             </IncidentInfectionChanceFactors>
           </IncidentInfectable>
           <Culture />
+        </Values>
+      </Asset>          
+      <Asset>
+        <Template>AssetPool</Template>
+        <Values>
+          <Standard>
+            <GUID>1500040019</GUID>
+            <Name>AssetPool Geographic Society</Name>
+          </Standard>
+          <AssetPool>
+            <AssetList>
+              <Item>
+                <Asset>1500040012</Asset>
+              </Item>
+              <Item>
+                <Asset>1500040013</Asset>
+              </Item>
+            </AssetList>
+          </AssetPool>
         </Values>
       </Asset>
     </ModOp>

--- a/sub/nw-tier4/data/config/export/main/asset/menu.include.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/menu.include.xml
@@ -18,6 +18,10 @@
               <Patrono>0</Patrono>
             </Item>
             <Item>
+              <Building>1500040022</Building>
+              <Patrono>1</Patrono>
+            </Item>
+            <Item>
               <Building>120289</Building>
               <Patrono>1</Patrono>
             </Item>

--- a/sub/nw-tier4/data/config/export/main/asset/population.include.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/population.include.xml
@@ -184,8 +184,8 @@
             </Item>
           </PopulationOutputs>
           <CategoryIcon>data/ui/2kimages/main/icons/icon_arrow.png</CategoryIcon>
-          <PopulationParticipant>Third_enemy_01_Grant</PopulationParticipant>
-          <PopulationAtWorkParticipant>Resident_tier05_atWork</PopulationAtWorkParticipant>
+          <PopulationParticipant>Mod6</PopulationParticipant>
+          <PopulationAtWorkParticipant>Mod6</PopulationAtWorkParticipant>
           <MoodText>
             <Angry>
               <Text>1500011690</Text>

--- a/sub/nw-tier4/data/config/export/main/asset/silverware.include.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/silverware.include.xml
@@ -26,9 +26,7 @@
           <ProductionChain>
             <Building>1500040007</Building>
           </ProductionChain>
-          <Locked>
-            <DefaultLockedState>0</DefaultLockedState>
-          </Locked>
+          <Locked />
         </Values>
       </Asset>
     </ModOp>
@@ -139,9 +137,7 @@
         <Constructable>
           <DestructionCategory>Production</DestructionCategory>
         </Constructable>
-        <Locked>
-          <DefaultLockedState>0</DefaultLockedState>
-        </Locked>
+        <Locked />
         <Object>
           <Variations>
             <Item>
@@ -194,5 +190,27 @@
         <UpgradeList />
       </Values>
     </Asset>
+      <Asset>
+        <Template>AssetPool</Template>
+        <Values>
+          <Standard>
+            <GUID>1500040017</GUID>
+            <Name>NW Silverware Pool</Name>
+          </Standard>
+          <AssetPool>
+            <AssetList>
+              <Item>
+                <Asset>1500040005</Asset>
+              </Item>
+              <Item>
+                <Asset>1500040006</Asset>
+              </Item>
+              <Item>
+                <Asset>1500040007</Asset>
+              </Item>
+            </AssetList>
+          </AssetPool>
+        </Values>
+      </Asset>
   </ModOp>
 </ModOps>

--- a/sub/nw-tier4/data/config/export/main/asset/theater.include.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/theater.include.xml
@@ -45,9 +45,7 @@
             </Tier1>
             <InfoTipHeight>550</InfoTipHeight>
           </ProductionChain>
-          <Locked>
-            <DefaultLockedState>0</DefaultLockedState>
-          </Locked>
+          <Locked />
         </Values>
       </Asset>
     </ModOp>
@@ -160,9 +158,7 @@
           <Constructable>
             <DestructionCategory>Production</DestructionCategory>
           </Constructable>
-          <Locked>
-            <DefaultLockedState>0</DefaultLockedState>
-          </Locked>
+          <Locked />
           <Object>
             <Variations>
               <Item>
@@ -228,6 +224,28 @@
           </Cost>
           <Infolayer />
           <UpgradeList />
+        </Values>
+      </Asset>       
+      <Asset>
+        <Template>AssetPool</Template>
+        <Values>
+          <Standard>
+            <GUID>1500040020</GUID>
+            <Name>AssetPool Geographic Society</Name>
+          </Standard>
+          <AssetPool>
+            <AssetList>
+              <Item>
+                <Asset>1500040014</Asset>
+              </Item>
+              <Item>
+                <Asset>1500040015</Asset>
+              </Item>
+              <Item>
+                <Asset>1500040016</Asset>
+              </Item>
+            </AssetList>
+          </AssetPool>
         </Values>
       </Asset>
     </ModOp>

--- a/sub/nw-tier4/data/config/export/main/asset/tiles.include.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/tiles.include.xml
@@ -1,0 +1,256 @@
+<ModOps>
+    <!-- # Menu -->
+    <Group>
+        <!-- Services [Artista or Patrono &lt;= 1]-->
+        <ModOp Type="addNextSibling" GUID="500138" Path="/Values/ConstructionCategory/BuildingList/Item[last()]">
+            <Item>
+                <Building>1500040022</Building>
+                <Patrono>1</Patrono>
+            </Item>
+        </ModOp>
+
+        <ModOp Type="addNextSibling" GUID="500002">
+            <Asset>
+                <Template>ProductionChain</Template>
+                <Values>
+                    <Standard>
+                        <GUID>1500040022</GUID>
+                        <Name>Tiles NW Chain</Name>
+                        <IconFilename>data/ui/kurila/icon_tiles.png</IconFilename>
+                    </Standard>
+                    <Text>
+                        <TextOverride>1500301073</TextOverride>
+                    </Text>
+                    <ProductionChain>
+                        <Building>1500040023</Building>
+                        <Tier1>
+                            <Item>
+                                <Building>101267</Building>
+                            </Item>
+                            <Item>
+                                <Building>5462</Building>
+                                <Tier2>
+                                    <Item>
+                                        <Building>1390</Building>
+                                    </Item>
+                                </Tier2>
+                            </Item>
+                            <Item>
+                                <Building>1010319</Building>
+                                <Tier2>
+                                    <Item>
+                                        <Building>1010560</Building>
+                                    </Item>
+                                </Tier2>
+                            </Item>
+                        </Tier1>
+                    </ProductionChain>
+                    <Locked>
+                        <DefaultLockedState>1</DefaultLockedState>
+                    </Locked>
+                </Values>
+            </Asset>
+            <Asset>
+                <Template>AssetPool</Template>
+                <Values>
+                    <Standard>
+                        <GUID>1500040024</GUID>
+                        <Name>NW Asset Pool Tiles</Name>
+                    </Standard>
+                    <AssetPool>
+                        <AssetList>
+                            <Item>
+                                <Asset>1500040022</Asset>
+                            </Item>
+                            <Item>
+                                <Asset>1500040023</Asset>
+                            </Item>
+                            <Item>
+                                <Asset>1500301073</Asset>
+                            </Item>
+                        </AssetList>
+                    </AssetPool>
+                </Values>
+            </Asset>
+            <Asset>
+                <Template>FactoryBuilding7</Template>
+                <Values>
+                    <Standard>
+                        <GUID>1500040023</GUID>
+                        <Name>DLC12 Tile Workshop</Name>
+                        <IconFilename>data/ui/kurila/icon_tiles.png</IconFilename>
+                    </Standard>
+                    <Building>
+                        <BuildModeRandomRotation>180</BuildModeRandomRotation>
+                        <AssociatedRegions>Colony01</AssociatedRegions>
+                        <SecondPartyRelevant>0</SecondPartyRelevant>
+                    </Building>
+                    <Blocking />
+                    <Cost>
+                        <Costs>
+                            <Item>
+                                <Ingredient>1010017</Ingredient>
+                                <Amount>12000</Amount>
+                            </Item>
+                            <Item>
+                                <Ingredient>1010196</Ingredient>
+                                <Amount>10</Amount>
+                            </Item>
+                            <Item>
+                                <Ingredient>1010205</Ingredient>
+                                <Amount>15</Amount>
+                            </Item>
+                            <Item>
+                                <Ingredient>1010218</Ingredient>
+                            </Item>
+                            <Item>
+                                <Ingredient>1010207</Ingredient>
+                            </Item>
+                            <Item>
+                                <Ingredient>1010202</Ingredient>
+                            </Item>
+                        </Costs>
+                    </Cost>
+                    <Object>
+                        <Variations>
+                            <Item>
+                                <Filename>data/dlc12/graphics/buildings/production/sewing_machines/sewing_machines_workshop.cfg</Filename>
+                            </Item>
+                        </Variations>
+                        <Skins>
+                            <DefaultSkinName>1500040023</DefaultSkinName>
+                            <DefaultSkinDescription>23853</DefaultSkinDescription>
+                            <DefaultSkinCategoryName>7312</DefaultSkinCategoryName>
+                        </Skins>
+                    </Object>
+                    <Mesh />
+                    <Selection>
+                        <OnSelection>
+                            <IsBaseAutoCreateAsset>1</IsBaseAutoCreateAsset>
+                            <Values>
+                                <ActionList />
+                            </Values>
+                        </OnSelection>
+                        <ParticipantMessageArcheType>Mod6</ParticipantMessageArcheType>
+                        <Colors>
+                            <WeakSelectionColorType>NoColor</WeakSelectionColorType>
+                        </Colors>
+                    </Selection>
+                    <Text>
+                        <LocaText>
+                            <English>
+                                <Text>Sewing Machine Factory</Text>
+                                <Status>Exported</Status>
+                            </English>
+                        </LocaText>
+                        <LineID>60132</LineID>
+                    </Text>
+                    <Constructable />
+                    <Locked />
+                    <SoundEmitter>
+                        <ActiveSounds>
+                            <Item>
+                                <Sound>200802</Sound>
+                            </Item>
+                            <Item>
+                                <Sound>201625</Sound>
+                            </Item>
+                        </ActiveSounds>
+                        <IncidentSounds>
+                            <InfectedFire>
+                                <Item>
+                                    <Sound>214659</Sound>
+                                </Item>
+                            </InfectedFire>
+                        </IncidentSounds>
+                    </SoundEmitter>
+                    <FeedbackController />
+                    <Infolayer />
+                    <UpgradeList />
+                    <Factory7 />
+                    <FactoryBase>
+                        <FactoryInputs>
+                            <Item>
+                                <Product>5400</Product>
+                                <Amount>1</Amount>
+                                <StorageAmount>4</StorageAmount>
+                            </Item>
+                            <Item>
+                                <Product>1010241</Product>
+                                <Amount>1</Amount>
+                                <StorageAmount>4</StorageAmount>
+                            </Item>
+                            <Item>
+                                <Product>1010201</Product>
+                                <Amount>1</Amount>
+                                <StorageAmount>4</StorageAmount>
+                            </Item>
+                        </FactoryInputs>
+                        <FactoryOutputs>
+                            <Item>
+                                <Product>1500301073</Product>
+                                <Amount>1</Amount>
+                                <StorageAmount>4</StorageAmount>
+                            </Item>
+                        </FactoryOutputs>
+                    </FactoryBase>
+                    <LogisticNode />
+                    <AmbientMoodProvider>
+                        <Murmur>Factory</Murmur>
+                        <DynamicEnvironmentType>None</DynamicEnvironmentType>
+                    </AmbientMoodProvider>
+                    <Maintenance>
+                        <Maintenances>
+                            <Item>
+                                <Product>1010017</Product>
+                                <Amount>100</Amount>
+                                <InactiveAmount>50</InactiveAmount>
+                            </Item>
+                            <Item>
+                                <Product>1500011558</Product>
+                                <Amount>50</Amount>
+                            </Item>
+                        </Maintenances>
+                    </Maintenance>
+                    <Attackable>
+                        <AttackableType>IslandBuilding</AttackableType>
+                        <MaximumHitPoints>5000</MaximumHitPoints>
+                        <SelfHealPerHealTick>6</SelfHealPerHealTick>
+                    </Attackable>
+                    <Pausable />
+                    <IncidentInfectable>
+                        <Infectable>
+                            <Explosion>
+                                <Base>0</Base>
+                                <Escalated>0</Escalated>
+                            </Explosion>
+                        </Infectable>
+                        <Explosion>
+                            <ExplosionCoreDamage>1000</ExplosionCoreDamage>
+                        </Explosion>
+                        <IncidentInfectionChanceFactors>
+                            <Fire>
+                                <DensityDistance>20</DensityDistance>
+                                <FactoryProductivityFactor>0.1</FactoryProductivityFactor>
+                                <FactoryUndertimeFactor>0.05</FactoryUndertimeFactor>
+                            </Fire>
+                            <Riot>
+                                <FactoryOvertimeFactor>0.4</FactoryOvertimeFactor>
+                                <FactoryUndertimeFactor>0.2</FactoryUndertimeFactor>
+                                <FactoryHappinessFactor>0.2</FactoryHappinessFactor>
+                                <HappinessThreshold>20</HappinessThreshold>
+                            </Riot>
+                        </IncidentInfectionChanceFactors>
+                    </IncidentInfectable>
+                    <Industrializable />
+                    <Culture>
+                        <CultureType>Culture</CultureType>
+                    </Culture>
+                    <QuestObject />
+                    <Electrifiable />
+                    <EcoSystemProvider />
+                </Values>
+            </Asset>
+        </ModOp>
+    </Group>
+</ModOps>

--- a/sub/nw-tier4/data/config/export/main/asset/unlocks.include.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/unlocks.include.xml
@@ -137,6 +137,60 @@
           <UsedBySecondParties>0</UsedBySecondParties>
         </TriggerSetup>
       </Values>
+    </Asset>    
+    <Asset>
+      <Template>Trigger</Template>
+      <Values>
+        <Standard>
+          <GUID>1500040021</GUID>
+          <Name>Unhide @ 1 Patrono | Intermediate NW 4.0</Name>
+        </Standard>
+        <Trigger>
+          <TriggerCondition>
+            <Template>ConditionPlayerCounter</Template>
+            <Values>
+              <Condition />
+              <ConditionPlayerCounter>
+                <PlayerCounter>PopulationByLevel</PlayerCounter>
+                <Context>1500011557</Context>
+                <CounterAmount>1</CounterAmount>
+              </ConditionPlayerCounter>
+            </Values>
+          </TriggerCondition>
+          <TriggerActions>
+            <Item>
+              <TriggerAction>
+                <Template>ActionUnlockAsset</Template>
+                <Values>
+                  <Action />
+                  <ActionUnlockAsset>
+                    <UnlockAssets>
+                      <Item>
+                        <Asset>1500040004</Asset>
+                      </Item>
+                      <Item>
+                        <Asset>1500040017</Asset>
+                      </Item>
+                      <Item>
+                        <Asset>1500040018</Asset>
+                      </Item>
+                      <Item>
+                        <Asset>1500040019</Asset>
+                      </Item>
+                      <Item>
+                        <Asset>1500040020</Asset>
+                      </Item>
+                    </UnlockAssets>
+                  </ActionUnlockAsset>
+                </Values>
+              </TriggerAction>
+            </Item>
+          </TriggerActions>
+        </Trigger>
+        <TriggerSetup>
+          <UsedBySecondParties>0</UsedBySecondParties>
+        </TriggerSetup>
+      </Values>
     </Asset>
   </ModOp>
 </ModOps>

--- a/sub/nw-tier4/data/config/export/main/asset/unlocks.include.xml
+++ b/sub/nw-tier4/data/config/export/main/asset/unlocks.include.xml
@@ -166,6 +166,9 @@
                   <ActionUnlockAsset>
                     <UnlockAssets>
                       <Item>
+                        <Asset>1500040024</Asset>
+                      </Item>
+                      <Item>
                         <Asset>1500040004</Asset>
                       </Item>
                       <Item>

--- a/sub/nw-tier4/data/config/gui/texts_english.xml
+++ b/sub/nw-tier4/data/config/gui/texts_english.xml
@@ -72,5 +72,9 @@
       <GUID>1500040014</GUID>
       <Text>Drama Theatre</Text>
     </Text>
+    <Text>
+      <GUID>1500040023</GUID>
+      <Text>Tile Workshop</Text>
+    </Text>
   </ModOp>
 </ModOps>

--- a/sub/nw-tier4/guids.md
+++ b/sub/nw-tier4/guids.md
@@ -1,0 +1,55 @@
+| GUID       | Name                     
+| ---------- | -------------------------
+| 1500011040 | Patrono Residence        
+| 1500011559 | @ 900 Artisans           
+| 1500011552 | @ 1 Engineer             
+| 1500011486 | Unhide @ 750 Artisans    
+| 601225301  | Unhide @ 1 Obrero        
+| 601225302  | @ 2000 Obreros           
+| 605883200  | intermediate moderate 4.0
+| 605883201  | intermediate moderate 4.0
+| 605883300  | nw\_capitolio            
+| 1500011556 | NW Patronos Menu         
+| 1500011557 | Patronos                 
+| 1500011558 | Patronos Workforce       
+| 1500011689 | New World Residents      
+| 1500011690 | Angry Patrono            
+| 1500011691 | Unhappy Patrono          
+| 1500011692 | Content Patrono          
+| 1500011693 | Happy Patrono            
+| 1500011694 | Euphoric Patrono         
+
+## Needs  
+
+| GUID       | Name                     
+| ---------- | -------------------------
+| 1500040000 | Member's Club
+| 1500040001 | Fedoras NW Chain
+| 1500040002 | Unhide @ 1 Obrero
+| 1500040003 | @ 2000 Obreros
+| 1500040005 | Silverware
+| 1500040006 | Silverware NW Chain
+| 1500040007 | Silverware Service Building
+| 1500040008 | Bank Service NW Chain
+| 1500040010 | Investment
+| 1500040011 | Silverware Service Building
+| 1500040012 | Geographic Society NW Chain
+| 1500040013 | Geographic Society Serice
+| 1500040014 | Drama Theatre Serice
+| 1500040015 | Drama Theatre
+| 1500040016 | Drama Theatre NW Chain
+
+## Asset Pools
+
+| GUID       | Name                     
+| ---------- | -------------------------
+
+| 1500040004 | AssetPool Fedora
+| 1500040017 | AssetPool Silverware |
+| 1500040018 | AssetPool Bank | 
+| 1500040019 | AssetPool Geographic Society | 
+| 1500040020 | AssetPool Drama Theatre |
+
+## Unlocks
+
+| 1500040021 | Intermediate NW 4.0 @ 1 Patrono |

--- a/sub/nw-tier4/guids.md
+++ b/sub/nw-tier4/guids.md
@@ -38,6 +38,11 @@
 | 1500040014 | Drama Theatre Serice
 | 1500040015 | Drama Theatre
 | 1500040016 | Drama Theatre NW Chain
+| 1500040022 | Chain Tiles |
+| 1500040023 | Production Tiles |
+| 1500040025 | Chain Feijoada |
+| 1500040026 | Production Feijoada |
+| 1500040028 | Product Feijoada |
 
 ## Asset Pools
 
@@ -49,6 +54,8 @@
 | 1500040018 | AssetPool Bank | 
 | 1500040019 | AssetPool Geographic Society | 
 | 1500040020 | AssetPool Drama Theatre |
+| 1500040024 | AssetPool Tiles |
+| 1500040027 | AssetPool Feijoada |
 
 ## Unlocks
 

--- a/sub/nw-tier4/modinfo.json
+++ b/sub/nw-tier4/modinfo.json
@@ -10,6 +10,7 @@
     "https://github.com/anno-mods/shared-resources/releases/download/v10.10/ToolTip_OtherResidences.zip",
     "https://github.com/jakobharder/shared-drakkam/releases/download/v4-jakob1/fedora-Drakkam.zip",
     "https://github.com/jakobharder/shared-drakkam/releases/download/v4-jakob1/ow-fedora-Drakkam.zip",
+    "https://github.com/Qurila/shared-mods/releases/download/v8/coloured_tiles_kurila.zip",
     "silver-newhorizons",
     "cars-newhorizons",
     "new_world_cathedral"


### PR DESCRIPTION
- Adds asset pools for all current production chains.
- Removes defaultlockedstate except for the Patrono residence
- Unlocks for cathedral and capitolio (obreros) is unchanged still
- Unlocks all Patrono asset pools at 1 patrono. 